### PR TITLE
FIX npm link will now automatically run after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "setup": "npm link",
     "prebuild": "rimraf dist",
     "build": "nest build",
+    "postbuild": "npm link",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
Fixed the bug where devs has to manually run "npm link" to symlink the console command after each build process 