### PR TITLE
Fixed: Not able to import default exports

### DIFF
--- a/libs/core/src/module.ts
+++ b/libs/core/src/module.ts
@@ -5,7 +5,7 @@ import {
   IsUniqueConstraint,
   IsValueFromConfigConstraint,
 } from './validator';
-import * as Knex from 'knex';
+import Knex from 'knex';
 import * as KnexConfig from '../../../knexfile';
 import { KNEX_CONNECTION } from './constants';
 import { BaseModel } from './db';

--- a/libs/core/src/validator/decorators/isDateInFormat.ts
+++ b/libs/core/src/validator/decorators/isDateInFormat.ts
@@ -5,7 +5,7 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
-import * as moment from 'moment';
+import moment from 'moment';
 
 @ValidatorConstraint({ async: true })
 class IsDateInFormatConstraint implements ValidatorConstraintInterface {
@@ -25,7 +25,7 @@ export function IsDateInFormat(
   format: string,
   validationOptions?: ValidationOptions,
 ) {
-  return function(object: Record<string, any>, propertyName: string): void {
+  return function (object: Record<string, any>, propertyName: string): void {
     registerDecorator({
       target: object.constructor,
       propertyName: propertyName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import { NestFactory, HttpAdapterHost } from '@nestjs/core';
 import { AppModule } from './app';
 import { useContainer } from 'class-validator';
-import * as bodyParser from 'body-parser';
-import * as helmet from 'helmet';
-import * as rateLimit from 'express-rate-limit';
+import bodyParser from 'body-parser';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import { RequestGuard, ExceptionFilter, TimeoutInterceptor } from '@libs/core';
 import { ConfigService } from '@nestjs/config';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
I have fixed default imports, Now we can write `import moment from 'moment';` instead of `import * as moment from 'moment';`