### PR TITLE
Feature/validator context binding

### DIFF
--- a/libs/core/src/http/controllers/rest.ts
+++ b/libs/core/src/http/controllers/rest.ts
@@ -1,6 +1,7 @@
+import { Request } from '../interfaces';
 import { get } from 'lodash';
 import { Transformer } from '../../transformers';
-
+ 
 export class RestController {
   /**
    * Transform a object
@@ -15,12 +16,12 @@ export class RestController {
     options?: Record<string, any>,
   ): Promise<Record<string, any>> {
     transformer = this.setTransformerContext(transformer, options);
-
+ 
     return await transformer
       .parseIncludes(this.getIncludes(options?.req))
       .work(obj);
   }
-
+ 
   /**
    * Transform collection/array
    *
@@ -34,7 +35,7 @@ export class RestController {
     options?: Record<string, any>,
   ): Promise<Array<Record<string, any>>> {
     transformer = this.setTransformerContext(transformer, options);
-
+ 
     const collection = [];
     for (const o of collect) {
       collection.push(
@@ -43,7 +44,7 @@ export class RestController {
     }
     return collection;
   }
-
+ 
   /**
    * Transform with paginate
    * @param obj
@@ -56,13 +57,13 @@ export class RestController {
     options?: Record<string, any>,
   ): Promise<Record<string, any>> {
     const collection = this.collection(obj.data, transformer, options);
-
+ 
     return {
       data: await collection,
       pagination: obj.pagination,
     };
   }
-
+ 
   private setTransformerContext(
     transformer: Transformer,
     options: Record<string, any>,
@@ -71,9 +72,13 @@ export class RestController {
     transformer.ctx.setRequest(options?.req || {});
     return transformer;
   }
-
+ 
   getIncludes(req: any) {
     if (!req) return '';
     return get(req.all(), 'include', '');
+  }
+ 
+  buildContext(req: Request): Record<string, any> {
+    return { user: req.user, ...req.all() };
   }
 }

--- a/libs/core/src/validator/decorators/exists.ts
+++ b/libs/core/src/validator/decorators/exists.ts
@@ -9,11 +9,17 @@ import { Injectable, Inject } from '@nestjs/common';
 import { KNEX_CONNECTION } from '../../constants';
 import * as Knex from 'knex';
 import { isEmpty } from 'lodash';
+import { ValidatorHelper } from '../validatorHelper';
 
 @Injectable()
 @ValidatorConstraint({ async: true })
-export class ExistsConstraint implements ValidatorConstraintInterface {
-  constructor(@Inject(KNEX_CONNECTION) private connection: Knex) {}
+export class ExistsConstraint
+  extends ValidatorHelper
+  implements ValidatorConstraintInterface
+{
+  constructor(@Inject(KNEX_CONNECTION) private connection: Knex) {
+    super();
+  }
 
   public async validate(
     value: string | string[],
@@ -34,7 +40,8 @@ export class ExistsConstraint implements ValidatorConstraintInterface {
       ? query.whereIn(column, value)
       : query.where(column, value);
 
-    if (where) query.where(where);
+    if (where)
+      query.where(this.resolveContext(where, (args.object as any)['$']));
 
     const result = await query.count({ count: '*' });
     const record = result[0] || {};

--- a/libs/core/src/validator/decorators/isUnique.ts
+++ b/libs/core/src/validator/decorators/isUnique.ts
@@ -9,45 +9,55 @@ import * as Knex from 'knex';
 import { Injectable, Inject } from '@nestjs/common';
 import { KNEX_CONNECTION } from '@libs/core/constants';
 import { isEmpty } from '@libs/core/helpers';
-
+import { ValidatorHelper } from '../validatorHelper';
+ 
 @Injectable()
 @ValidatorConstraint({ async: true })
-export class IsUniqueConstraint implements ValidatorConstraintInterface {
-  constructor(@Inject(KNEX_CONNECTION) private connection: Knex) {}
-
+export class IsUniqueConstraint
+  extends ValidatorHelper
+  implements ValidatorConstraintInterface
+{
+  constructor(@Inject(KNEX_CONNECTION) private connection: Knex) {
+    super();
+  }
+ 
   public async validate(
     value: string | string[],
     args: ValidationArguments,
   ): Promise<boolean> {
     if (isEmpty(value)) return false;
-
-    const [{ table, column, caseInsensitive, where }] = args.constraints;
-
+ 
+    const [{ table, column, caseInsensitive, where, whereNot }] =
+      args.constraints;
+ 
     if (caseInsensitive) {
       value = Array.isArray(value)
         ? value.map((v) => v.toLowerCase())
         : value.toLowerCase();
     }
-
+ 
     const query = this.connection(table);
     Array.isArray(value)
       ? query.whereIn(column, value)
       : query.where(column, value);
-
-    if (where) query.where(where);
-
+ 
+    if (where)
+      query.where(this.resolveContext(where, (args.object as any)['$']));
+    if (whereNot)
+      query.whereNot(this.resolveContext(whereNot, (args.object as any)['$']));
+ 
     const result = await query.count({ count: '*' });
     const record = result[0] || {};
     const count = +record['count'];
     return Array.isArray(value) ? !!!(value.length === count) : !!!count;
   }
-
+ 
   defaultMessage(args: ValidationArguments) {
     const [options] = args.constraints;
     return `${options.column} already exists.`;
   }
 }
-
+ 
 export function IsUnique(
   options: Record<string, any>,
   validationOptions?: ValidationOptions,

--- a/libs/core/src/validator/validatorHelper.ts
+++ b/libs/core/src/validator/validatorHelper.ts
@@ -1,0 +1,22 @@
+export class ValidatorHelper {
+    
+    resolveContext(condition: Record<string, any>, context: Record<string, any>) {
+      const where = { ...condition };
+      for (let key in where) {
+        let value = where[key];
+        if (typeof value != 'string') continue;
+        if (!value.includes('$.')) continue;
+        let path = value.split('$.')[1];
+        where[key] = this.getDeepValue({ ...context }, path);
+      }
+      return where;
+    }
+   
+    getDeepValue(obj, path) {
+      path = path.split('.');
+      for (let i = 0, len = path.length; i < len; i++) {
+        obj = obj[path[i]];
+      }
+      return obj;
+    }
+  }


### PR DESCRIPTION
With these changes we can now bind the request object to the validator and this enables us to dynamically use request object values inside DTOs using “$” placeholder.

To bind the request object pass <class instance>.buildContext(<req>) as the third parameter to validator.fire function .
This can currently be used inside Exists() and IsUnique() decorators.